### PR TITLE
Fix: Remove duplicate function and variable declarations

### DIFF
--- a/bc.html
+++ b/bc.html
@@ -444,7 +444,6 @@
         return files;
     }
 
-    let dragCounter = 0;
     function handleDragEnter(e) { e.preventDefault(); dragCounter++; dom.dragOverlay.classList.remove('hidden'); }
     function handleDragLeave(e) { e.preventDefault(); dragCounter--; if (dragCounter === 0) dom.dragOverlay.classList.add('hidden'); }
 
@@ -882,7 +881,7 @@
             }
         }
     }
-    
+
     function saveSettings() {
         const provider = dom.providerSelect.value;
         const apiKey = dom.apiKeyInput.value.trim();
@@ -961,31 +960,6 @@
 
         dom.providerSelect.addEventListener('change', updateSettingsUI);
         dom.saveSettingsBtn.addEventListener('click', saveSettings);
-    }
-
-    async function handleTerminalKeydown(e) {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            const commandLine = dom.terminalInput.value.trim();
-            if (commandLine) {
-                appendToTerminal(`${dom.terminalPromptPrefix.textContent} ${commandLine}`);
-                dom.terminalInput.value = '';
-                state.terminal.history.push(commandLine);
-                state.terminal.historyIndex = state.terminal.history.length;
-                await evaluateCommand(commandLine);
-            }
-        } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-            e.preventDefault();
-            const direction = e.key === 'ArrowUp' ? -1 : 1;
-            const newIndex = state.terminal.historyIndex + direction;
-            if (newIndex >= 0 && newIndex < state.terminal.history.length) {
-                state.terminal.historyIndex = newIndex;
-                dom.terminalInput.value = state.terminal.history[state.terminal.historyIndex];
-            } else if (direction === 1) {
-                state.terminal.historyIndex = state.terminal.history.length;
-                dom.terminalInput.value = '';
-            }
-        }
     }
 
     async function handleTerminalKeydown(e) {


### PR DESCRIPTION
This commit fixes a `SyntaxError` that occurred because the `dragCounter` variable and the `handleTerminalKeydown` function were declared twice.

This was likely due to a copy-paste error during the reordering of the functions. This commit removes the duplicate declarations.