### PR TITLE
feat: Use Sparky image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A retro-inspired, AI-powered web desktop environment that runs entirely in your browser.
 
-![Screenshot of k8OS](https://i.imgur.com/your-screenshot.png)
-*(Note: Please replace this with an actual screenshot of the project.)*
+![A picture of Sparky, the k8OS assistant](sparky.svg)
 
 k8OS is a sophisticated, client-side web application that simulates a desktop operating system environment. It features a classic graphical user interface with windows, icons, a taskbar, and a start menu. What makes k8OS unique is its suite of integrated applications, many of which are powered by generative AI, allowing users to create games, music, and graphics with simple text prompts.
 

--- a/sparky.svg
+++ b/sparky.svg
@@ -1,0 +1,62 @@
+<svg id="assistantAvatarSVG" viewBox="0 0 100 100" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        /* Default animation for sparkyBobbingGroup */
+        #sparkyBobbingGroup {
+            transform-origin: 50% 50%;
+            animation-name: sparkyWander;
+            animation-duration: 10s;
+            animation-timing-function: ease-in-out;
+            animation-iteration-count: infinite;
+        }
+        /* When .rolling class is added to sparkyBobbingGroup */
+        #sparkyBobbingGroup.rolling {
+            animation-name: sparkyRoll, sparkyWander;
+            animation-duration: 1s, 10s;
+            animation-timing-function: ease-in-out, ease-in-out;
+            animation-iteration-count: 1, infinite;
+            animation-delay: 0s, 1.05s; /* Roll first, then wander starts after 1.05s */
+        }
+
+        @keyframes sparkyWander {
+            0%   { transform: translate(0px, 0px) rotate(0deg); }
+            15%  { transform: translate(4px, -3px) rotate(3deg); }
+            30%  { transform: translate(-2px, 1px) rotate(-2deg); }
+            45%  { transform: translate(5px, -2px) rotate(2deg); }
+            60%  { transform: translate(0px, 2px) rotate(0deg); }
+            75%  { transform: translate(-4px, -3px) rotate(-3deg); }
+            90%  { transform: translate(2px, 0px) rotate(1deg); }
+            100% { transform: translate(0px, 0px) rotate(0deg); }
+        }
+         @keyframes sparkyRoll {
+            0%   { transform: translate(0px, 0px) rotate(0deg) scale(1); }
+            50%  { transform: translate(0px, 0px) rotate(180deg) scale(1.1); }
+            100% { transform: translate(0px, 0px) rotate(360deg) scale(1); }
+        }
+
+        #sparkyEyelid { animation: sparkyBlink 4.5s ease-in-out infinite; transform-origin: 50% 35%; /* Blink from top of eye */ }
+        @keyframes sparkyBlink {
+            0%, 90%, 100% { opacity: 0; transform: scaleY(0.1)}
+            93% { opacity: 1; transform: scaleY(1)}
+            96% { opacity: 0; transform: scaleY(0.1)}
+        }
+        #sparkyMouth.talking { animation: sparkyTalk 0.25s infinite steps(2, end); }
+        @keyframes sparkyTalk {
+            0% { d: path("M 40 60 Q 50 63 60 60"); }
+            50% { d: path("M 40 60 Q 50 68 60 60"); }
+        }
+    </style>
+    <defs>
+        <radialGradient id="sparkyBodyGradient" cx="50%" cy="50%" r="50%" fx="50%" fy="50%">
+            <stop offset="0%" style="stop-color:#87CEFA;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#4682B4;stop-opacity:1" />
+        </radialGradient>
+        <filter id="sparkyGlow"><feGaussianBlur stdDeviation="1.5" result="coloredBlur"/><feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    </defs>
+    <g id="sparkyBobbingGroup">
+        <circle cx="50" cy="50" r="32" fill="url(#sparkyBodyGradient)" filter="url(#sparkyGlow)"/>
+        <ellipse cx="50" cy="45" rx="14" ry="9" fill="white"/>
+        <ellipse id="sparkyEyelid" cx="50" cy="45" rx="14.5" ry="9.5" fill="url(#sparkyBodyGradient)" opacity="0"/>
+        <circle id="sparkyPupil" cx="50" cy="45" r="4.5" fill="#222"/>
+        <path id="sparkyMouth" d="M 40 60 Q 50 63 60 60" stroke="#333" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+    </g>
+</svg>


### PR DESCRIPTION
This commit updates the `README.md` to use an image of Sparky, the k8OS assistant, as the main screenshot.

- Extracts the SVG code for the Sparky avatar from `index.html`.
- Creates a new `sparky.svg` file with the avatar.
- Updates the `README.md` to display `sparky.svg`.