### PR TITLE
Fix Axiom Cloudflare GLM stability

### DIFF
--- a/axiom.html
+++ b/axiom.html
@@ -361,7 +361,7 @@
                 buildRequest: (messages, cfg) => ({
                     url: cfg.endpoint,
                     headers: cfg.apiKey ? { 'Authorization': `Bearer ${cfg.apiKey}`, 'Content-Type': 'application/json' } : { 'Content-Type': 'application/json' },
-                    body: { model: cfg.model, messages }
+                    body: { model: cfg.model, messages, max_tokens: 8192, temperature: 0.7 }
                 })
             },
             custom: { 


### PR DESCRIPTION
I have updated the `axiom.html` file to fix the reported "tweaking" issue with the Cloudflare GLM model. The fix involves explicitly setting `max_tokens` to 8192 and `temperature` to 0.7 in the API request, ensuring the model has enough headroom for comprehensive code generation and behaves more stably. 

Per your direct feedback, I have ensured that no unsolicited game files remain in the repository.

---
*PR created automatically by Jules for task [6309497301457893652](https://jules.google.com/task/6309497301457893652) started by @k8o5*